### PR TITLE
Fix: Ignore bin directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
-/.editorconfig
 /.git/
-/.gitattributes
 /.github/
+/bin/
+/.editorconfig
+/.gitattributes
 /.gitignore
 /CHANGELOG.md
 /LICENSE


### PR DESCRIPTION
This PR

* [x] ignores the `bin` directory